### PR TITLE
Allowed loading files with acquisition ratio >1

### DIFF
--- a/redshirt/read.py
+++ b/redshirt/read.py
@@ -29,20 +29,21 @@ def read_image(fn, normalize=True):
     ----------
     .. [1] http://www.redshirtimaging.com/support/dfo.html
     """
-    data = np.memmap(fn, dtype=np.int16, mode='r')
+    data = np.fromfile(fn,dtype = np.int16)
     header_size = 2560
     header = data[:header_size]
     ncols, nrows = map(int, header[384:386])  # prevent int16 overflow
     nframes = int(header[4])
     frame_interval = header[388] / 1000
+    acquisition_ratio = header[391]
     if frame_interval >= 10:
         frame_interval *= header[390]  # dividing factor
     image_size = nrows * ncols * nframes
     bnc_start = header_size + image_size
-    images = np.reshape(np.array(data[header_size:bnc_start]),
-                        (nrows, ncols, nframes))
-    bnc_end = bnc_start + 8 * nframes
-    bnc = np.reshape(np.array(data[bnc_start:bnc_end]), (8, nframes))
+    images = np.rollaxis(np.reshape(np.array(data[header_size:bnc_start]),
+                        (nrows, ncols, nframes)),-1)
+    bnc_end = bnc_start + 8 * acquisition_ratio * nframes
+    bnc = np.reshape(np.array(data[bnc_start:bnc_end]), (8, nframes * acquisition_ratio))
     dark_frame = np.reshape(np.array(data[bnc_end:-8]), (nrows, ncols))
     if normalize:
         images -= dark_frame[..., np.newaxis]

--- a/redshirt/read.py
+++ b/redshirt/read.py
@@ -1,6 +1,7 @@
 import numpy as np
 from skimage import io
 
+
 def read_image(fn, normalize=True):
     """Read a CCD/CMOS image in .da format (Redshirt). [1_]
 
@@ -29,7 +30,7 @@ def read_image(fn, normalize=True):
     ----------
     .. [1] http://www.redshirtimaging.com/support/dfo.html
     """
-    data = np.fromfile(fn,dtype = np.int16)
+    data = np.fromfile(fn, dtype=np.int16)
     header_size = 2560
     header = data[:header_size]
     ncols, nrows = map(int, header[384:386])  # prevent int16 overflow

--- a/redshirt/read.py
+++ b/redshirt/read.py
@@ -40,8 +40,8 @@ def read_image(fn, normalize=True):
         frame_interval *= header[390]  # dividing factor
     image_size = nrows * ncols * nframes
     bnc_start = header_size + image_size
-    images = np.rollaxis(np.reshape(np.array(data[header_size:bnc_start]),
-                        (nrows, ncols, nframes)),-1)
+    images = np.reshape(np.array(data[header_size:bnc_start]),
+                        (nrows, ncols, nframes))
     bnc_end = bnc_start + 8 * acquisition_ratio * nframes
     bnc = np.reshape(np.array(data[bnc_start:bnc_end]), (8, nframes * acquisition_ratio))
     dark_frame = np.reshape(np.array(data[bnc_end:-8]), (nrows, ncols))


### PR DESCRIPTION
This project failed if the acquisition ratio (electrical signal data rate/camera frame rate) was greater than 1. I added the capability to deal with this. 

I also changed the loading from memmap to  fromfile. This is because memmap failed to load the correct data with my set up - I am unsure why. I don't think that this is a disadvantage as the all of the data is loaded into memory anyway.